### PR TITLE
Download 24.10.0-rc2 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mtd3: 00600000 00020000 "kernel"
 mtd4: 0f7c0000 00020000 "ubi"
 ```
 
-The scripts in this repository can be used to migrate existing installs 21.02, 22.03 or 23.05 to the new layout. It will install the latest 24.10 snapshot to your device. Hopefully these scripts will be backported to 23.05 in the next stable release
+The scripts in this repository can be used to migrate existing installs 21.02, 22.03 or 23.05 to the new layout. It will install the latest 24.10 release candidate to your device. Hopefully these scripts will be backported to 23.05 in the next stable release
 
 ## Migration
 
@@ -31,7 +31,11 @@ The scripts in this repository can be used to migrate existing installs 21.02, 2
 	./ubnt_erx_migrate.sh
 	```
 5. This will download firmware update, check sha256 sums, then flash new kernel and rootfs and finally reboot.
-
+## Snapshot
+You can instead install a 24.10 snapshot build with this command:
+```sh
+SNAPSHOT=y ./ubnt_erx_migrate.sh
+```
 ## Local Install
 you can also build your own openwrt snapshot and migrate directly to that:
 - Host `openwrt-ramips-mt7621-ubnt_edgerouter-x-squashfs-sysupgrade.bin` on a webserver on your lan

--- a/ubnt_erx_migrate.sh
+++ b/ubnt_erx_migrate.sh
@@ -8,12 +8,19 @@ include /lib/upgrade
 
 BOARD="$(board_name | sed 's/,/_/g')"
 
-# Use snapshots until a stable 24.x release
-SITE="https://downloads.openwrt.org/releases/24.10-SNAPSHOT/targets/ramips/mt7621/"
-PATTERN="${BOARD}-squashfs-sysupgrade.bin"
-FILE=$(wget -qO- "$SITE" | grep -oP '(?<=href=")[^"]*' | grep "$PATTERN" | head -n 1)
-tar_file="/tmp/sysupgrade.img"
+RC="24.10.0-rc2"
+SITE="https://downloads.openwrt.org/releases/${RC}/targets/ramips/mt7621/"
+SNAPSITE="https://downloads.openwrt.org/releases/24.10-SNAPSHOT/targets/ramips/mt7621/"
+
+if [ -n "$SNAPSHOT" ]; then
+    SITE=${SNAPSITE}
+fi
+
 SITE=${TESTSITE:-$SITE}
+PATTERN="${BOARD}-squashfs-sysupgrade.bin"
+FILE=$(wget -qO- "$SITE" | grep -o 'href="[^"]*' | sed 's/href="//' | grep "$PATTERN" | head -n 1)
+tar_file="/tmp/sysupgrade.img"
+
 
 
 confirm_migration() {
@@ -45,6 +52,7 @@ confirm_migration() {
 }
 
 download_image(){
+    echo "Downloading $SITE/$FILE"
     wget -qO "$tar_file" "$SITE/$FILE"
     sha256=$(wget -qO- "$SITE/sha256sums" | grep "$PATTERN" | cut -d ' ' -f1)
     sha256local=$(sha256sum "$tar_file" | cut -d ' ' -f1)


### PR DESCRIPTION
  Use 24.10.0-rc2 images by default
    
  or optionally migrate directly to latest snapshot build
```sh
  SNAPSHOT=y ./ubnt_erx_migrate.sh
```