### PR TITLE
Fix migration from factory.tar image

### DIFF
--- a/ubnt_erx_migrate.sh
+++ b/ubnt_erx_migrate.sh
@@ -9,6 +9,10 @@ include /lib/upgrade
 export VERBOSE=1
 BOARD="$(board_name | sed 's/,/_/g')"
 
+if [ ! -d /etc/ssl/certs/ ]; then
+    WGET_OPTS="--no-check-certificate"
+fi
+
 RC="24.10.0-rc2"
 SITE="https://downloads.openwrt.org/releases/${RC}/targets/ramips/mt7621/"
 SNAPSITE="https://downloads.openwrt.org/releases/24.10-SNAPSHOT/targets/ramips/mt7621/"
@@ -19,7 +23,7 @@ fi
 
 SITE=${TESTSITE:-$SITE}
 PATTERN="${BOARD}-squashfs-sysupgrade.bin"
-FILE=$(wget -qO- "$SITE" | grep -o 'href="[^"]*' | sed 's/href="//' | grep "$PATTERN" | head -n 1)
+FILE=$(wget ${WGET_OPTS} -qO- "$SITE" | grep -o 'href="[^"]*' | sed 's/href="//' | grep "$PATTERN" | head -n 1)
 tar_file="/tmp/sysupgrade.img"
 
 
@@ -54,8 +58,8 @@ confirm_migration() {
 
 download_image(){
     echo "Downloading $SITE/$FILE"
-    wget -qO "$tar_file" "$SITE/$FILE"
-    sha256=$(wget -qO- "$SITE/sha256sums" | grep "$PATTERN" | cut -d ' ' -f1)
+    wget ${WGET_OPTS} -qO "$tar_file" "$SITE/$FILE"
+    sha256=$(wget ${WGET_OPTS} -qO- "$SITE/sha256sums" | grep "$PATTERN" | cut -d ' ' -f1)
     sha256local=$(sha256sum "$tar_file" | cut -d ' ' -f1)
     if [ "$sha256" != "$sha256local" ]; then
             echo "Downloaded image checksum mismatch" >&2


### PR DESCRIPTION
After install factory.tar image from EdgeOS UI, the system is in an intermediate state and still running the compressed image entirely out of kernel slot. There are 2 issues here:

- Certificates are not installed, to save space. Ignore certificate errors in this case.
- We need to cleanup to leftover ubi volume from factory image.

Users can now migratre directly from the intermediate state without having to sysupgrade to a proper OpenWRT install first.