### PR TITLE
Avoid error on empty compat value

### DIFF
--- a/ubnt_erx_migrate.sh
+++ b/ubnt_erx_migrate.sh
@@ -33,8 +33,8 @@ confirm_migration() {
         ubnt,edgerouter-x|\
         ubnt,edgerouter-x-sfp)
             compat=$(uci -q get system.@system[0].compat_version)
-            if [ "$compat" != "1.1" ]; then
-                echo "Incompatible compat version $compat" >&2
+            if [ -n "$compat" ] && [ "$compat" == "2.0" ]; then
+                echo "Device already migrated to new layout" >&2
                 exit 1
             fi
             ;;


### PR DESCRIPTION
Some users may be missing a compat value if they have used backups of old systems (from prior dsa switch).

Just ignore if compat if it is missing, we can upgrade anyway. 